### PR TITLE
Add basic statistics feature with FastAPI and Vue

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,61 @@
+const { createApp, ref } = Vue
+
+createApp({
+  setup() {
+    const columns = ref([])
+    const dataRows = ref([])
+    const showPopup = ref(false)
+    const selectedStats = ref([])
+    const selectedColumns = ref([])
+    const results = ref({})
+
+    const statOptions = [
+      { label: '평균', value: 'mean' },
+      { label: '중앙값', value: 'median' },
+      { label: '표준편차', value: 'std' },
+      { label: '최솟값', value: 'min' },
+      { label: '최댓값', value: 'max' },
+      { label: '결측치 수', value: 'null_count' },
+    ]
+
+    const statLabels = {
+      mean: '평균',
+      median: '중앙값',
+      std: '표준편차',
+      min: '최솟값',
+      max: '최댓값',
+      null_count: '결측치 수'
+    }
+
+    function loadCsv(e) {
+      const file = e.target.files[0]
+      if (!file) return
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (res) => {
+          dataRows.value = res.data
+          columns.value = res.meta.fields
+        }
+      })
+    }
+
+    async function runStats() {
+      const payload = {
+        data: dataRows.value,
+        columns: selectedColumns.value,
+        stats: selectedStats.value
+      }
+      const res = await fetch('http://localhost:8000/api/basic-stats', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      const json = await res.json()
+      results.value = json.results
+      showPopup.value = false
+    }
+
+    return { columns, dataRows, showPopup, selectedStats, selectedColumns, results, statOptions, statLabels, loadCsv, runStats }
+  }
+}).mount('#app')

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Statistics App</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/papaparse@5.4.1/papaparse.min.js"></script>
+</head>
+<body class="p-4" >
+  <div id="app">
+    <input type="file" @change="loadCsv" class="mb-4" />
+    <button v-if="columns.length" @click="showPopup = true" class="bg-blue-500 text-white px-4 py-2">기초 통계량</button>
+
+    <div v-if="showPopup" class="fixed inset-0 flex items-center justify-center bg-gray-700 bg-opacity-50">
+      <div class="bg-white p-4 rounded w-96">
+        <h2 class="text-xl mb-2">통계 설정</h2>
+        <div class="mb-2">
+          <label v-for="stat in statOptions" :key="stat.value" class="block">
+            <input type="checkbox" v-model="selectedStats" :value="stat.value" /> {{ stat.label }}
+          </label>
+        </div>
+        <div class="mb-2">
+          <label class="block mb-1">분석 열 선택</label>
+          <select multiple v-model="selectedColumns" class="w-full border">
+            <option v-for="col in columns" :key="col" :value="col">{{ col }}</option>
+          </select>
+        </div>
+        <div class="text-right">
+          <button @click="runStats" class="bg-green-500 text-white px-3 py-1 mr-2">실행</button>
+          <button @click="showPopup = false" class="bg-gray-300 px-3 py-1">닫기</button>
+        </div>
+      </div>
+    </div>
+
+    <table v-if="Object.keys(results).length" class="mt-4 table-auto border-collapse border">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">항목</th>
+          <th v-for="col in selectedColumns" :key="col" class="border px-2 py-1">{{ col }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="stat in selectedStats" :key="stat">
+          <td class="border px-2 py-1">{{ statLabels[stat] }}</td>
+          <td v-for="col in selectedColumns" :key="col" class="border px-2 py-1">{{ results[col][stat] }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/py_server/README.md
+++ b/py_server/README.md
@@ -1,0 +1,10 @@
+# Python Statistics API
+
+This FastAPI server provides a `/api/basic-stats` endpoint to compute basic statistics on uploaded CSV data.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```

--- a/py_server/main.py
+++ b/py_server/main.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Dict, Any
+import pandas as pd
+
+app = FastAPI()
+
+class StatsRequest(BaseModel):
+    data: List[Dict[str, Any]]
+    columns: List[str]
+    stats: List[str]
+
+@app.post('/api/basic-stats')
+def basic_stats(req: StatsRequest):
+    df = pd.DataFrame(req.data)
+    results = {}
+    for col in req.columns:
+        series = pd.to_numeric(df[col], errors='coerce')
+        col_res = {}
+        if 'mean' in req.stats:
+            val = series.mean()
+            col_res['mean'] = None if pd.isna(val) else float(val)
+        if 'median' in req.stats:
+            val = series.median()
+            col_res['median'] = None if pd.isna(val) else float(val)
+        if 'std' in req.stats:
+            val = series.std()
+            col_res['std'] = None if pd.isna(val) else float(val)
+        if 'min' in req.stats:
+            val = series.min()
+            col_res['min'] = None if pd.isna(val) else float(val)
+        if 'max' in req.stats:
+            val = series.max()
+            col_res['max'] = None if pd.isna(val) else float(val)
+        if 'null_count' in req.stats:
+            col_res['null_count'] = int(series.isna().sum())
+        results[col] = col_res
+    return {'results': results}

--- a/py_server/requirements.txt
+++ b/py_server/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pandas


### PR DESCRIPTION
## Summary
- implement FastAPI server under `py_server` with `/api/basic-stats` endpoint
- add lightweight Vue.js UI in `client` to upload CSV, choose stats/columns, and display results
- convert numpy values to standard Python types in API output

## Testing
- `pip install -r requirements.txt`
- `uvicorn main:app --port 8000 --reload` *(manual test)*
- `curl -s -X POST http://localhost:8000/api/basic-stats -H 'Content-Type: application/json' -d '{"data": [{"A": 1, "B": 2}, {"A": 3, "B": 4}], "columns": ["A","B"], "stats": ["mean", "max"]}'`


------
https://chatgpt.com/codex/tasks/task_e_686123c916ac8329a5d4504268d20d52